### PR TITLE
compile error on alpine linux

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-How to compile
+ How to compile
 --------------
 
 Congratulations, you checked out the simutrans source. To compile it,


### PR DESCRIPTION
musl libc doesn't support PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP.
the _NP at the end means "non portable". that means it shouldn't be used.

instead the portable way is
```c
pthread_mutex_t Mutex;
pthread_mutexattr_t Attr;

pthread_mutexattr_init(&Attr);
pthread_mutexattr_settype(&Attr, PTHREAD_MUTEX_RECURSIVE);
pthread_mutex_init(&Mutex, &Attr);
```

according to https://stackoverflow.com/questions/7037481/c-how-do-you-declare-a-recursive-mutex-with-posix-threads

i'm usign a bogus PR to report this issue, since "issues" are not available in this repo.