### PR TITLE
system-wide install

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ If you are on a MS Windows machine, download either MS VC Express or
 MSYS2. MSVC is easy for debugging, MSYS2 is easy to set up (but it has to be done on the commandline).
 
 The packages needed for MSYS2 are
-make
+make 
 mingw-w64-i686-gcc
 mingw-w64-i686-SDL (Only if you want an SDL build OR for sound on SDL2)
 mingw-w64-i686-SDL2 (Only if you want an SDL2 build)


### PR DESCRIPTION
it'd be nice if there was a way to make a systemwide install. e.g.
user supplies a data-basepath /share/simutrans where he can install all the data files into

(a standard install with the same behaviour as right now would have the BASE_PATH defined as ".")

pathes.h then uses like
FONT_PATH   BASE_PATH "/font"
FONT_PATH_X   BASE_PATH "/font/"

i created a patch that does just that but there are other place that use chdir (!) previous to opening files...

```
$ cat /tmp/log | grep theme
15392 chdir("themes")                   = -1 ENOENT (No such file or directory)
15392 open("themes.tab", O_RDONLY)      = -1 ENOENT (No such file or directory)
15392 writev(2, [{"", 0}, {"FATAL ERROR: simmain() - No GUI themes found! Please re-install!\nAborting program execution ...\n\nFor help with this error or to file a bug report please see the Simutrans forum at\nhttp://forum.simutrans.com\n", 207}], 2) = 207
```

if a base path is provided, saves and screenshot would go into getenv("HOME") + "/.simutrans/..." because the home dir of a user is r/w, the data dir /share/simutrans not.