### PR TITLE
after get_lang_files.sh screen is shown, simutrans aborts immediately

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -26,7 +26,7 @@ http://alleg.sourceforge.net/index.de.html
 To make life easier, you can follow the instructions to compile OpenTTD:
 http://wiki.openttd.org/Category:Compiling_OpenTTD
 A system set up for OpenTTD will also compile simutrans (except for
-bzlib2, see below sections).
+bzlib2, see below sections).  
 
 If you are on a MS Windows machine, download either MS VC Express or
 MSYS2. MSVC is easy for debugging, MSYS2 is easy to set up (but it has to be done on the commandline).


### PR DESCRIPTION
and thus one doesn't have time to read the message about get_lang_files.sh

i was only able to see it after i started simutrans with gdb