### PR TITLE
Add an option to the Makefile for creating compile_command.sjson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /Release
 /build
 /config.*
+/compile_commands.json
 /makeobj/makeobj
 /makeobj/makeobj.exe
 *sim

--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@ DIRS := $(sort $(dir $(OBJS)))
 # Make build directories
 DUMMY := $(shell mkdir -p $(DIRS))
 
-.PHONY: all clean
+.PHONY: all clean compile-commands
 
 .SUFFIXES: .rc
 
@@ -29,6 +29,13 @@ clean:
 	$(Q)rm -fr $(PROGDIR)/$(PROG).app
 
 -include $(DEPS)
+
+compile-commands:
+	@echo "[" > compile_commands.json
+	@for file in $(SOURCES); do \
+		echo "{ \"directory\": \"$(PROGDIR)\", \"command\": \"$(HOSTCXX) $(CXXFLAGS) -c -MMD $$(pwd)/$$file\", \"file\": \"$$(pwd)/$$file\"  }," >> compile_commands.json; \
+	done;
+	@echo "{ \"directory\": \"no\", \"command\": \"trailing\", \"file\": \"comma\"}]" >> compile_commands.json
 
 # Silence stale header dependency errors
 %.h:


### PR DESCRIPTION
`compile_command.json` is a compilation database files used by different  clangd based IDEs and editors for more accurate code completion.

In this patch a make target `compile-commands` is added as a PHONY    target which creates such a file. The target is PHONY for easy updating    of the database file.

The logic used for creating is trivial and will treat all files as C++    (even the `.m`, `.mm` and `.c` files) and won't do escaping of `"` in    any path. The resulting file is created in the root directory, not inside the build dir, so IDEs and tools can find it easily.
    
Information on `compile_commands.json` can be found on    https://clang.llvm.org/docs/JSONCompilationDatabase.html
