### PR TITLE
SDL: Use external midi sequencer software when arg with "-midicmd foo".

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -84,6 +84,7 @@ bool env_t::player_finance_display_account = true;
 
 // the following initialisation is not important; set values in init()!
 std::string env_t::objfilename;
+std::string env_t::midi_command = "";
 bool env_t::night_shift;
 bool env_t::hide_with_transparency;
 bool env_t::hide_trees;
@@ -254,6 +255,7 @@ void env_t::init()
 	mute_sound = false;
 	mute_midi = false;
 	shuffle_midi = true;
+	midi_command = "";
 
 	left_to_right_graphs = false;
 
@@ -388,7 +390,20 @@ void env_t::rdwr(loadsave_t *file)
 	file->rdwr_bool( mute_sound );
 	file->rdwr_bool( mute_midi );
 	file->rdwr_bool( shuffle_midi );
+	/*
+	 * ToDo: Include midi command to settings.xml
+	 * Nov 20, 2019 K.Ohta
+	 */
+	/*
 
+	if(  file->is_version_atleast(120, 4)  ) {
+		plainstring str = midi_command.c_str();
+		file->rdwr_str( str );
+		if(  file->is_loading()  ) {
+			midi_command = str ? str.c_str() : "";
+		}
+	}
+	*/
 	if(  file->is_version_atleast(102, 2)  ) {
 		file->rdwr_byte( show_vehicle_states );
 		file->rdwr_bool( left_to_right_graphs );

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -427,6 +427,7 @@ public:
 
 	static sint16 global_volume, midi_volume;
 	static bool mute_sound, mute_midi, shuffle_midi;
+	static std::string midi_command;
 
 	/// @}
 

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -33,6 +33,7 @@
 
 settings_t::settings_t() :
 	filename(""),
+	midi_command(""),
 	heightfield("")
 {
 	size_x = 256;
@@ -869,6 +870,7 @@ void settings_t::parse_simuconf(tabfile_t& simuconf, sint16& disp_width, sint16&
 		env_t::fontname = fname;
 	}
 
+	env_t::midi_command = contents.get_string( "midi_command", env_t::midi_command.c_str());
 	env_t::water_animation = contents.get_int("water_animation_ms", env_t::water_animation );
 	env_t::ground_object_probability = contents.get_int("random_grounds_probability", env_t::ground_object_probability );
 	env_t::moving_object_probability = contents.get_int("random_wildlife_probability", env_t::moving_object_probability );

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -151,6 +151,7 @@ private:
 	sint16 bits_per_month;
 
 	std::string filename;
+	std::string midi_command;
 
 	bool beginner_mode;
 	sint32 beginner_price_factor;
@@ -427,6 +428,9 @@ public:
 
 	void set_filename(const char *n) {filename=n;}	// prissi, Jun-06
 	const char* get_filename() const { return filename.c_str(); }
+
+	void set_midi_command(const char *n) {midi_command = n;}  // K.Ohta Nov-19
+	const char *get_midi_command() const { return midi_command.c_str(); }
 
 	bool get_beginner_mode() const {return beginner_mode;}
 

--- a/music/sdl_midi.cc
+++ b/music/sdl_midi.cc
@@ -12,10 +12,13 @@
 
 #include "../simdebug.h"
 #include "../utils/plainstring.h"
+#include "../dataobj/environment.h"
+#include "../dataobj/settings.h"
 #include "music.h"
 
 static int         midi_number = -1;
 static plainstring midi_filenames[MAX_MIDI];
+static char *ext_cmd_name = NULL;
 
 //Mix_Music *music[MAX_MIDI];
 Mix_Music *music = NULL;
@@ -65,7 +68,16 @@ void dr_play_midi(int key)
 		dr_stop_midi();
 	}
 	music = Mix_LoadMUS(midi_filenames[key]);
-	Mix_PlayMusic(music, 1);
+	/*
+	 * If error on loading MIDI with external CMD, use internal MIDI decoder.
+	 */
+	if(	Mix_PlayMusic(music, 1) != 0 && ext_cmd_name != NULL) {
+		Mix_SetMusicCMD(NULL);
+		dbg->warning( "dr_play_midi()", "Failed to execute external MIDI PLAYER because %s, using fallback internal player.", ext_cmd_name, Mix_GetError() );
+		ext_cmd_name = NULL;
+		music = Mix_LoadMUS(midi_filenames[key]);
+		Mix_PlayMusic(music, 1);
+	}
 }
 
 
@@ -117,6 +129,24 @@ void dr_destroy_midi(void)
  */
 bool dr_init_midi(void)
 {
+	const char *arg_midi_cmd = env_t::default_settings.get_midi_command();
+	if(arg_midi_cmd != NULL) {
+		if(strlen(arg_midi_cmd) > 0) {
+			if(Mix_SetMusicCMD(arg_midi_cmd) != -1) {
+				ext_cmd_name = (char *)arg_midi_cmd;
+			}
+		}
+	}
+	if(ext_cmd_name == NULL) {
+		ext_cmd_name = SDL_getenv((const char *)"SIMUTRANS_MIDI_CMD");
+	}
+	if(ext_cmd_name != NULL && strlen(ext_cmd_name) > 0) {
+		if(Mix_SetMusicCMD(ext_cmd_name) == 0) {
+			DBG_MESSAGE("simmain", "Using \"%s\" instead of internal player.\n", ext_cmd_name);
+			return true;
+		}
+	}
+	
 	if(!SDL_WasInit(SDL_INIT_AUDIO)) {				//if audio not init
 		if(SDL_InitSubSystem(SDL_INIT_AUDIO) != -1) {		//if audio subsys is ok
 			if(Mix_OpenAudio(22050, AUDIO_S16SYS, 2, 1024)==-1) {

--- a/simmain.cc
+++ b/simmain.cc
@@ -459,6 +459,7 @@ int simu_main(int argc, char** argv)
 			" -mute               mute all sounds\n"
 			" -noaddons           does not load any addon (default)\n"
 			" -nomidi             turns off background music\n"
+			" -midicmd COMMAND    set external midi command.(default environment variable SIMUTRANS_MIDI_CMD)\n"
 			" -nosound            turns off ambient sounds\n"
 			" -objects DIR_NAME/  load the pakset in specified directory\n"
 			" -pause              starts game with paused after loading\n"
@@ -978,7 +979,10 @@ int simu_main(int argc, char** argv)
 			env_t::default_settings.set_with_private_paks( false );
 		}
 	}
-
+	// Set external midi command.
+	if(const char *  midi_cmd = gimme_arg(argc, argv, "-midicmd", 1) ) {
+			env_t::default_settings.set_midi_command( midi_cmd );
+	}
 	// parse ~/simutrans/pakxyz/config.tab"
 	if(  env_t::default_settings.get_with_private_paks()  ) {
 		obj_conf = string(env_t::user_dir) + "addons/" + env_t::objfilename + "config/simuconf.tab";


### PR DESCRIPTION
Configure for SDL/SDL2 with SDL_Mixer, loading and playing midi file(s) are very slowly and eats a lot of CPU time.

Because Mix_LoadMUS() tries to decode full track of a MIDI file to raw PCM data as default (maybe with some distros), this spend a lot of time.

But, at SDL_Mixer, available to use external command as a MIDI (or some formats) decoder, i.e. timidity.

So, I add a feature using external midi sequencer when running with ARG "-midicmd foo" or setting a environment variable; SIMUTRANS_MIDI_CMD.
