### PR TITLE
configuration to make trains stop at the designated position of halt

### DIFF
--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -302,7 +302,7 @@ settings_t::settings_t() :
 	frames_per_step = 4;
 	server_frames_ahead = 4;
 
-	advance_to_end = true;
+	stop_halt_as_scheduled = true;
 }
 
 
@@ -922,7 +922,7 @@ void settings_t::rdwr(loadsave_t *file)
 		}
 
 		if(  file->is_version_atleast(122, 2)  ) {
-			file->rdwr_bool(advance_to_end);
+			file->rdwr_bool(stop_halt_as_scheduled);
 		}
 		// otherwise the default values of the last one will be used
 	}
@@ -1590,7 +1590,7 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	world_maximum_height = contents.get_int_clamped("world_maximum_height", world_maximum_height, 16, 127);
 	world_minimum_height = contents.get_int_clamped("world_minimum_height", world_minimum_height, -127, -12);
 
-	advance_to_end = contents.get_int("advance_to_end", advance_to_end);
+	stop_halt_as_scheduled = contents.get_int("stop_halt_as_scheduled", stop_halt_as_scheduled);
 
 	// Default pak file path
 	objfilename = ltrim(contents.get_string("pak_file_path", objfilename.c_str() ) );

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -314,8 +314,8 @@ private:
 	// true if companies can make ways public
 	bool disable_make_way_public;
 
-	// only for trains. If true, trains advance to the end of the platform.
-	bool advance_to_end;
+	// only for trains. If true, trains stop at the position designated in the schdule..
+	bool stop_halt_as_scheduled;
 
 public:
 	/* the big cost section */
@@ -662,8 +662,8 @@ public:
 	bool get_departures_on_time() const { return departures_on_time; }
 	void set_departures_on_time(bool b) { departures_on_time = b; }
 
-	bool get_advance_to_end() const { return advance_to_end; }
-	void set_advance_to_end(bool b) { advance_to_end = b; }
+	bool get_stop_halt_as_scheduled() const { return stop_halt_as_scheduled; }
+	void set_stop_halt_as_scheduled(bool b) { stop_halt_as_scheduled = b; }
 };
 
 #endif

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -237,7 +237,7 @@ void settings_routing_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "way_max_bridge_len", sets->way_max_bridge_len, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "way_leaving_road", sets->way_count_leaving_road, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
 	SEPERATOR
-	INIT_BOOL( "advance_to_end", sets->get_advance_to_end() );
+	INIT_BOOL( "stop_halt_as_scheduled", sets->get_stop_halt_as_scheduled() );
 
 	INIT_END
 }
@@ -265,7 +265,7 @@ void settings_routing_stats_t::read(settings_t* const sets)
 	READ_NUM_VALUE( sets->way_max_bridge_len );
 	READ_NUM_VALUE( sets->way_count_leaving_road );
 
-	READ_BOOL_VALUE( sets->advance_to_end );
+	READ_BOOL_VALUE( sets->stop_halt_as_scheduled );
 }
 
 

--- a/vehicle/rail_vehicle.cc
+++ b/vehicle/rail_vehicle.cc
@@ -140,7 +140,7 @@ bool rail_vehicle_t::calc_route(koord3d start, koord3d ziel, sint32 max_speed, r
 	cnv->set_next_reservation_index( 0 ); // nothing to reserve
 	target_halt = halthandle_t(); // no block reserved
 	// use length 8888 tiles to advance to the end of all stations
-	const uint16 convoy_length = world()->get_settings().get_advance_to_end() ? 8888 : cnv->get_tile_length();
+	const uint16 convoy_length = world()->get_settings().get_stop_halt_as_scheduled() ? cnv->get_tile_length() : 8888;
 	return route->calc_route(welt, start, ziel, this, max_speed, convoy_length );
 }
 


### PR DESCRIPTION
**NOTE: This PR is only for code review. It's not intended to be merged.**
Please close this PR after the patch is merged via SVN.

# Summary
I want to add a configuration parameter that enables trains to stop at the designated position of the halt.
When the map is configured to do so, trains stop at the position designated in the schedule as long as the platform covers the entire convoy.

# The forum thread
https://forum.simutrans.com/index.php/topic,21195.0.html