### PR TITLE
Fix typo in compiler definition macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,7 @@ if (SIMUTRANS_STEAM_BUILT)
 endif ()
 
 if (SIMUTRANS_USE_OWN_PAKINSTALL)
-	target_compile_definitions(simutrans PRIVATE USE_OWN_PAKINSTAL=1)
+	target_compile_definitions(simutrans PRIVATE USE_OWN_PAKINSTALL=1)
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
`USE_OWN_PAKINSTALL` (referenced 10 more times in the code) was spelled `USE_OWN_PAKINSTAL` - missing the last "L".